### PR TITLE
Lo que se hizo:

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import threading
+from datetime import datetime
 import wx
 
 from utils.iam.create_users import create_users
@@ -30,12 +31,33 @@ class LogRedirector:
         "[INICIO]":   (100, 0,   140),
         "[CONSULTA]": (0,   80,  160),
     }
+    _LOG_DIR = "logs"
 
     def __init__(self, target: wx.TextCtrl):
         self._target = target
+        self._buf = ""
+        self._file = self._open_log_file()
+        self._write_log(f"{'=' * 54}")
+        self._write_log(f"Sesión iniciada — {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        self._write_log(f"{'=' * 54}")
+
+    def _open_log_file(self):
+        os.makedirs(self._LOG_DIR, exist_ok=True)
+        path = os.path.join(self._LOG_DIR, f"{datetime.now().strftime('%Y-%m-%d')}.log")
+        return open(path, "a", encoding="utf-8")
+
+    def _write_log(self, line: str):
+        ts = datetime.now().strftime("%H:%M:%S")
+        self._file.write(f"[{ts}] {line}\n")
+        self._file.flush()
 
     def write(self, text: str):
         wx.CallAfter(self._append, text)
+        self._buf += text
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            if line.strip():
+                self._write_log(line)
 
     def _append(self, text: str):
         color = wx.BLACK
@@ -49,6 +71,12 @@ class LogRedirector:
 
     def flush(self):
         pass
+
+    def close(self):
+        if self._buf.strip():
+            self._write_log(self._buf)
+        self._write_log(f"Sesión cerrada — {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        self._file.close()
 
 
 _HUAWEI_REGIONS = [
@@ -881,6 +909,8 @@ class MainFrame(wx.Frame):
         dlg.Destroy()
 
     def _on_close(self, event):
+        if isinstance(sys.stdout, LogRedirector):
+            sys.stdout.close()
         sys.stdout = sys.__stdout__
         event.Skip()
 


### PR DESCRIPTION
- LogRedirector.__init__ — abre (o crea) logs/2026-04-24.log en modo append y escribe un encabezado de sesión.
- write() — acumula texto en un buffer y cada vez que llega un \n escribe la línea completa con timestamp [HH:MM:SS] al archivo. **La GUI sigue funcionando igual.**
- close() — escribe el cierre de sesión y cierra el archivo.
- MainFrame._on_close — llama a close() antes de restaurar sys.stdout.