### PR TITLE
Ya no se congela la ventana 

### DIFF
--- a/gui/panels/create.py
+++ b/gui/panels/create.py
@@ -137,10 +137,14 @@ class CreatePanel(ProgressMixin, wx.ScrolledWindow):
             wx.CallAfter(self.update_gauge, value, label)
 
         def task():
-            print(f"\n[INICIO] Creando usuarios desde '{csv_file}'...")
-            create_users(csv_file, group_name=group_name, on_progress=progress)
-            wx.CallAfter(self.stop_progress)
-            wx.CallAfter(self._busy, False)
+            try:
+                print(f"\n[INICIO] Creando usuarios desde '{csv_file}'...")
+                create_users(csv_file, group_name=group_name, on_progress=progress)
+            except Exception as e:
+                print(f"[ERROR] Operación interrumpida: {e}")
+            finally:
+                wx.CallAfter(self.stop_progress)
+                wx.CallAfter(self._busy, False)
 
         run_thread(task)
 
@@ -175,9 +179,13 @@ class CreatePanel(ProgressMixin, wx.ScrolledWindow):
                          f"{verb} usuarios  {current}/{total}")
 
         def task():
-            print(f"\n[INICIO] {verb} usuarios...")
-            action(csv_file, on_progress=progress if n > 0 else None)
-            wx.CallAfter(self.stop_progress)
-            wx.CallAfter(self._busy, False)
+            try:
+                print(f"\n[INICIO] {verb} usuarios...")
+                action(csv_file, on_progress=progress if n > 0 else None)
+            except Exception as e:
+                print(f"[ERROR] Operación interrumpida: {e}")
+            finally:
+                wx.CallAfter(self.stop_progress)
+                wx.CallAfter(self._busy, False)
 
         run_thread(task)

--- a/gui/panels/delete.py
+++ b/gui/panels/delete.py
@@ -93,10 +93,14 @@ class DeletePanel(ProgressMixin, wx.ScrolledWindow):
         self.start_pulse(f"Eliminando grupo '{name}'...")
 
         def task():
-            print(f"\n[INICIO] Eliminando grupo '{name}' y sus recursos...")
-            delete_all(name)
-            wx.CallAfter(self.stop_progress)
-            wx.CallAfter(self._busy, False)
+            try:
+                print(f"\n[INICIO] Eliminando grupo '{name}' y sus recursos...")
+                delete_all(name)
+            except Exception as e:
+                print(f"[ERROR] Operación interrumpida: {e}")
+            finally:
+                wx.CallAfter(self.stop_progress)
+                wx.CallAfter(self._busy, False)
 
         run_thread(task)
 
@@ -119,16 +123,20 @@ class DeletePanel(ProgressMixin, wx.ScrolledWindow):
         self.start_pulse(f"Eliminando {tipo} '{name}'...")
 
         def task():
-            print(f"\n[INICIO] Eliminando {tipo} '{name}'...")
-            if tipo == "Usuario":
-                delete_single_user(name, extra)
-            elif tipo == "ECS":
-                delete_single_ecs(name)
-            elif tipo == "Subnet":
-                delete_single_subnet(name, extra)
-            elif tipo == "VPC":
-                delete_single_vpc(name)
-            wx.CallAfter(self.stop_progress)
-            wx.CallAfter(self._busy, False)
+            try:
+                print(f"\n[INICIO] Eliminando {tipo} '{name}'...")
+                if tipo == "Usuario":
+                    delete_single_user(name, extra)
+                elif tipo == "ECS":
+                    delete_single_ecs(name)
+                elif tipo == "Subnet":
+                    delete_single_subnet(name, extra)
+                elif tipo == "VPC":
+                    delete_single_vpc(name)
+            except Exception as e:
+                print(f"[ERROR] Operación interrumpida: {e}")
+            finally:
+                wx.CallAfter(self.stop_progress)
+                wx.CallAfter(self._busy, False)
 
         run_thread(task)

--- a/gui/panels/list_panel.py
+++ b/gui/panels/list_panel.py
@@ -111,22 +111,26 @@ class ListPanel(ProgressMixin, wx.Panel):
         self.start_pulse(f"Consultando {opcion.lower()}...")
 
         def task():
-            print(f"\n[CONSULTA] {opcion}" + (f": {filtro}" if filtro else ""))
             items = []
-            if opcion == "Grupos IAM":
-                items = list_groups()
-            elif opcion == "Usuarios de un grupo":
-                items = list_group_users(filtro)
-            elif opcion == "ECS de un grupo":
-                items = list_ecs_for_group(filtro)
-            elif opcion == "ECS de un usuario":
-                items = list_ecs_for_user(filtro)
-            elif opcion == "VPCs":
-                items = list_vpcs()
-            elif opcion == "Subnets de una VPC":
-                items = list_subnets_for_vpc(filtro)
-            wx.CallAfter(self.stop_progress)
-            wx.CallAfter(self._populate, opcion, items)
-            wx.CallAfter(self.btn_list.Enable)
+            try:
+                print(f"\n[CONSULTA] {opcion}" + (f": {filtro}" if filtro else ""))
+                if opcion == "Grupos IAM":
+                    items = list_groups()
+                elif opcion == "Usuarios de un grupo":
+                    items = list_group_users(filtro)
+                elif opcion == "ECS de un grupo":
+                    items = list_ecs_for_group(filtro)
+                elif opcion == "ECS de un usuario":
+                    items = list_ecs_for_user(filtro)
+                elif opcion == "VPCs":
+                    items = list_vpcs()
+                elif opcion == "Subnets de una VPC":
+                    items = list_subnets_for_vpc(filtro)
+            except Exception as e:
+                print(f"[ERROR] Consulta fallida: {e}")
+            finally:
+                wx.CallAfter(self.stop_progress)
+                wx.CallAfter(self._populate, opcion, items)
+                wx.CallAfter(self.btn_list.Enable)
 
         run_thread(task)


### PR DESCRIPTION
La ventana ya no se congela porque todas las operaciones pesadas van a un hilo con run_thread. El problema latente era diferente: si el SDK lanzaba una excepción no capturada, el hilo moría silenciosamente y la UI quedaba atascada (barra de progreso activa, botones deshabilitados para siempre) sin mostrar ningún mensaje en el log.

Con finally, el error queda visible en el log de la GUI y los botones se reactivan correctamente sin importar si la operación tuvo éxito o falló.